### PR TITLE
WIP: Remove system user from query results

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -281,7 +281,7 @@ after_initialize do
       (value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_by')::int AS staff_id,
       u.username_lower AS staff_username,
       value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'raw' AS note,
-      value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_at' AS created_at
+      (value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_at')::date AS created_at
       FROM plugin_store_rows
       JOIN users u
       ON u.id = (value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_by')::int
@@ -298,6 +298,7 @@ after_initialize do
       FROM notes n
       JOIN users u
       ON u.id = n.user_id
+      ORDER BY n.created_at DESC
       SQL
 
       DB.query(sql).each do |row|

--- a/plugin.rb
+++ b/plugin.rb
@@ -263,8 +263,8 @@ after_initialize do
     )
   end
 
-  if respond_to? :add_report
-    add_report('staff_notes') do |report|
+  if Report.respond_to? :add_report
+    Report.add_report('staff_notes') do |report|
       report.modes = [:table]
 
       report.data = []
@@ -286,7 +286,6 @@ after_initialize do
       JOIN users u
       ON u.id = (value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_by')::int
       WHERE plugin_name = 'staff_notes'
-      AND u.id > 0
       AND (value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_at')::date >= '#{report.start_date}'
       AND (value::jsonb->(jsonb_array_length(value::jsonb) - 1)->>'created_at')::date <= '#{report.end_date}'
       )

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Report do
   describe 'staff notes report' do
-    let(:report) { Report.find('staff_notes', start_date: 1.month.ago.beginning_of_day, end_date: Date.today.end_of_day) }
+    let(:report) { Report.find('staff_notes') }
     let(:user) { Fabricate(:user) }
     let(:mod) { Fabricate(:admin) }
     let(:first_topic) { Fabricate(:topic) }

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Report do
+  describe 'staff notes report' do
+    let(:report) { Report.find('staff_notes', start_date: 1.month.ago.beginning_of_day, end_date: Date.today.end_of_day) }
+    let(:user) { Fabricate(:user) }
+    let(:mod) { Fabricate(:admin) }
+    let(:first_topic) { Fabricate(:topic) }
+    let(:second_topic) { Fabricate(:topic) }
+
+    context "when there are no staff notes" do
+      before do
+        SiteSetting.staff_notes_enabled = true
+      end
+
+      it "should return a report with no data" do
+        expect(report.data).to be_blank
+      end
+    end
+
+    context "when there are staff notes" do
+      before do
+        SiteSetting.staff_notes_enabled = true
+        UserWarning.create(topic_id: first_topic.id, user_id: user.id, created_by_id: mod.id)
+        UserWarning.create(topic_id: second_topic.id, user_id: user.id, created_by_id: mod.id)
+      end
+
+      it "should return the most recent note for the user" do
+        expect(report.data[0][:note]).to match(/#{second_topic.title}/)
+      end
+
+      it "should return the user URLs" do
+        expect(report.data[0][:user_url]).to eq("/admin/users/#{user.id}/#{user.username_lower}")
+        expect(report.data[0][:moderator_url]).to eq("/admin/users/-1/system")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This removes the system user from the staff_notes report query. It also returns the results for the last staff_note for a user, instead of the first_staff note, if there is more than one note for a user. I will look at it again on Monday.