### PR TITLE
UX: Don't show user-notes icon on user-card if there's no notes

### DIFF
--- a/assets/javascripts/discourse-user-notes/connectors/user-card-post-names/show-user-notes-on-card.js.es6
+++ b/assets/javascripts/discourse-user-notes/connectors/user-card-post-names/show-user-notes-on-card.js.es6
@@ -5,7 +5,14 @@ import { emojiUrlFor } from "discourse/lib/text";
 export default {
   shouldRender(args, component) {
     const { siteSettings, currentUser } = component;
-    return siteSettings.user_notes_enabled && currentUser && currentUser.staff;
+    const { user } = args;
+    const count = user.user_notes_count || user.custom_fields.user_notes_count;
+    return (
+      siteSettings.user_notes_enabled &&
+      currentUser &&
+      currentUser.staff &&
+      count >= 1
+    );
   },
 
   setupComponent(args, component) {


### PR DESCRIPTION
Staff can add user-notes. This works without issue. However, if a user only has one user-note, and that note is deleted, then the icon for user notes stays visible in the use-card for that user. This PR fixes that. 

Before 

![before0100](https://user-images.githubusercontent.com/33972521/65615756-6fa6f780-dfec-11e9-83ff-50eda88c31c2.png)

After

![after0100](https://user-images.githubusercontent.com/33972521/65615766-733a7e80-dfec-11e9-96ad-e9570cf4df54.png)

Note that the plugin still has a few places where we use `foo.get('bar')` and those should probably be cleaned up in preparation for Octane

