### PR TITLE
FIX: Switch Discourse.base_uri usage to base_path

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -118,7 +118,7 @@ after_initialize do
         url = "/t/#{object[:post].topic_id}/#{object[:post].post_number}"
       end
 
-      "#{Discourse.base_uri}#{url}"
+      "#{Discourse.base_path}#{url}"
     end
 
     def post_title


### PR DESCRIPTION
base_uri was deprecated, because the name was unclear.