### PR TITLE
Add border to top of add-user-note button

### DIFF
--- a/assets/javascripts/discourse/initializers/enable-user-notes.js.es6
+++ b/assets/javascripts/discourse/initializers/enable-user-notes.js.es6
@@ -90,6 +90,7 @@ export default {
             label: "user_notes.attach",
             action: "showUserNotes",
             secondaryAction: "closeAdminMenu",
+            className: "add-user-note",
           })
         );
       });

--- a/assets/stylesheets/user_notes.scss
+++ b/assets/stylesheets/user_notes.scss
@@ -82,3 +82,7 @@
     }
   }
 }
+
+.add-user-note {
+  border-top: 1px solid rgba(var(--primary-low-rgb), 0.5);
+}


### PR DESCRIPTION
This adds a border to the top of the user-note list item / button in the admin panel on topics.

### After

<img width="817" alt="image" src="https://user-images.githubusercontent.com/30537603/127898441-e5dc4c10-bdb0-46e4-bd83-6c3aa75b007e.png">

### Before
<img width="865" alt="image" src="https://user-images.githubusercontent.com/30537603/127898482-2cacc0bd-1c28-4e1f-a2b4-954a8f7638ec.png">
