### PR TITLE
DEV: Fix pluginId warnings

### DIFF
--- a/assets/javascripts/discourse/initializers/enable-user-notes.js.es6
+++ b/assets/javascripts/discourse/initializers/enable-user-notes.js.es6
@@ -3,6 +3,8 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { showUserNotes } from "discourse/plugins/discourse-user-notes/discourse-user-notes/lib/user-notes";
 import { observes, on } from "discourse-common/utils/decorators";
 
+const PLUGIN_ID = "discourse-user-notes";
+
 export default {
   name: "enable-user-notes",
   initialize(container) {
@@ -38,6 +40,7 @@ export default {
       });
 
       api.modifyClass("controller:user", {
+        pluginId: PLUGIN_ID,
         userNotesCount: null,
 
         @on("init")


### PR DESCRIPTION
# Problem 
Depreciation errors were being thrown on initialization of plugin
```
To prevent errors, add a `pluginId` key to your changes when calling `modifyClass`
```

# Updates

- Added a pluginId to satisfy the canModify method and resolve depreciation errors

```
function canModify(klass, type, resolverName, changes) {
  if (!changes.pluginId) {
    console.warn(
      "To prevent errors, add a `pluginId` key to your changes when calling `modifyClass`"
    );
    return true;
  }
```