### PR TITLE
UX: Fix alignment of user profile buttons

### DIFF
--- a/assets/javascripts/discourse-user-notes/templates/connectors/user-profile-controls/show-notes-on-profile.hbs
+++ b/assets/javascripts/discourse-user-notes/templates/connectors/user-profile-controls/show-notes-on-profile.hbs
@@ -1,6 +1,4 @@
-<li>
-  {{show-user-notes
-    show=(action "showUserNotes")
-    count=userNotesCount
-  }}
-</li>
+{{show-user-notes
+  show=(action "showUserNotes")
+  count=userNotesCount
+}}


### PR DESCRIPTION
There's already a list element, the duplicate was causing this misalignment: 

<img width="388" alt="image" src="https://user-images.githubusercontent.com/368961/134990822-57df40de-ac4e-4973-9cdb-490efab0cec7.png">
