### PR TITLE
FIX: Use period filters passed into plugin for admin reports

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/admin-dashboard-moderation-bottom/recent-user-notes-report-table.hbs
+++ b/assets/javascripts/discourse/templates/connectors/admin-dashboard-moderation-bottom/recent-user-notes-report-table.hbs
@@ -1,7 +1,6 @@
 {{#if siteSettings.user_notes_enabled}}
-  {{admin-report
-    dataSourceName="user_notes"
-    startDate=lastWeek
-    endDate=endDate
-  }}
+  <AdminReport
+    @dataSourceName="user_notes"
+    @filters={{this.args.filters}}
+  />
 {{/if}}


### PR DESCRIPTION
This replaces previously undefined period filters passed into `AdminReport` component with args passed in from core

See https://github.com/discourse/discourse/pull/19182