### PR TITLE
FIX: Note info not appearing

### DIFF
--- a/assets/javascripts/discourse/templates/modal/user-notes.hbs
+++ b/assets/javascripts/discourse/templates/modal/user-notes.hbs
@@ -32,7 +32,7 @@
         </div>
 
         <div class="cooked">
-          {{cook-text n.raw}}
+          <CookText @rawText={{n.raw}} />
         </div>
 
         {{#if n.post_id}}


### PR DESCRIPTION
Since the core change (https://github.com/discourse/discourse/commit/61571bee43eae88755b5e258e96d03c146f9d2cb) of the `CookText` component to a Glimmer component, positional arguments are no longer supported, causing the note info to break.

This PR updates the component usage to angle bracket syntax with name arguments to fix the issue. This syntax will work on older versions as well, therefore, no `discourse-compatibility` file update is necessary.