### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/modal/user-notes.hbs
+++ b/assets/javascripts/discourse/components/modal/user-notes.hbs
@@ -27,7 +27,7 @@
             <span class="controls">
               <DButton
                 @action={{fn this.removeNote n}}
-                @icon="far-trash-alt"
+                @icon="far-trash-can"
                 @title="user_notes.remove"
                 class="btn-small btn-danger"
               />

--- a/assets/javascripts/discourse/components/show-user-notes.hbs
+++ b/assets/javascripts/discourse/components/show-user-notes.hbs
@@ -1,6 +1,6 @@
 <DButton
   class="btn-default show-user-notes-btn"
   @action={{@show}}
-  @icon="pencil-alt"
+  @icon="pencil"
   @translatedLabel={{this.label}}
 />

--- a/assets/javascripts/discourse/initializers/enable-user-notes.js
+++ b/assets/javascripts/discourse/initializers/enable-user-notes.js
@@ -95,7 +95,7 @@ export default {
       });
       api.addPostAdminMenuButton((attrs) => {
         return {
-          icon: "pencil-alt",
+          icon: "pencil",
           label: "user_notes.attach",
           action: (post) => {
             showUserNotes(


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.