### PR TITLE
UX: update emoji, better icon match

### DIFF
--- a/assets/javascripts/discourse-user-notes/connectors/after-reviewable-post-user/show-user-notes-on-flags.hbs
+++ b/assets/javascripts/discourse-user-notes/connectors/after-reviewable-post-user/show-user-notes-on-flags.hbs
@@ -8,11 +8,11 @@
       <img
         src={{this.emojiUrl}}
         title={{this.userNotesTitle}}
-        alt="pencil"
+        alt=""
         class="emoji"
       />
     {{else}}
-      {{d-icon "note-sticky"}}
+      {{d-icon "pen-to-square"}}
     {{/if}}
   </DButton>
 {{/if}}

--- a/assets/javascripts/discourse-user-notes/connectors/after-reviewable-post-user/show-user-notes-on-flags.js
+++ b/assets/javascripts/discourse-user-notes/connectors/after-reviewable-post-user/show-user-notes-on-flags.js
@@ -15,7 +15,7 @@ export default {
     component.setProperties({
       userNotesCount,
       emojiEnabled: component.siteSettings.enable_emoji,
-      emojiUrl: emojiUrlFor("pencil"),
+      emojiUrl: emojiUrlFor("memo"),
       userNotesTitle: i18n("user_notes.show", { count: userNotesCount }),
     });
   },

--- a/assets/javascripts/discourse-user-notes/connectors/user-card-post-names/show-user-notes-on-card.gjs
+++ b/assets/javascripts/discourse-user-notes/connectors/user-card-post-names/show-user-notes-on-card.gjs
@@ -43,9 +43,9 @@ export default class extends Component {
           class="btn-flat"
         >
           {{#if this.siteSettings.enable_emoji}}
-            {{emoji "pencil"}}
+            {{emoji "memo"}}
           {{else}}
-            {{icon "note-sticky"}}
+            {{icon "pen-to-square"}}
           {{/if}}
         </DButton>
       {{/if}}

--- a/assets/javascripts/discourse/components/show-user-notes.hbs
+++ b/assets/javascripts/discourse/components/show-user-notes.hbs
@@ -1,6 +1,6 @@
 <DButton
   class="btn-default show-user-notes-btn"
   @action={{@show}}
-  @icon="pencil"
+  @icon="pen-to-square"
   @translatedLabel={{this.label}}
 />

--- a/assets/javascripts/discourse/initializers/enable-user-notes.js
+++ b/assets/javascripts/discourse/initializers/enable-user-notes.js
@@ -70,7 +70,7 @@ export default {
       });
       api.addPostAdminMenuButton((attrs) => {
         return {
-          icon: "pencil",
+          icon: "pen-to-square",
           label: "user_notes.attach",
           action: (post) => {
             showUserNotes(
@@ -103,9 +103,9 @@ export default {
 
         html() {
           if (this.siteSettings.enable_emoji) {
-            return this.attach("emoji", { name: "pencil" });
+            return this.attach("emoji", { name: "memo" });
           } else {
-            return iconNode("note-sticky");
+            return iconNode("pen-to-square");
           }
         },
       });

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,7 +11,7 @@ enabled_site_setting :user_notes_enabled
 
 register_asset "stylesheets/user_notes.scss"
 
-register_svg_icon "note-sticky"
+register_svg_icon "pen-to-square"
 
 after_initialize do
   require_dependency "user"


### PR DESCRIPTION
This updates the emoji name to get the previous version back (switched to pencil recently) and also updates the icon to be a closer match to the emoji. 

Before:

![image](https://github.com/user-attachments/assets/4c00bc75-56fc-4750-af9d-896ef49830d9)
![image](https://github.com/user-attachments/assets/8b4c8e96-bd1e-4956-bd3f-ad618af8124d)


After:

![image](https://github.com/user-attachments/assets/ef3b5d11-a58f-4074-8a6d-a471fb75d8c3)
![image](https://github.com/user-attachments/assets/c4f7a820-f567-4dff-afa9-644938a561db)
