### PR TITLE
DEV: Add an option to copy reviewable notes when they're created.

### DIFF
--- a/assets/javascripts/discourse/connectors/reviewable-note-form-after-note/copy-reviewable-note-to-user-option.gjs
+++ b/assets/javascripts/discourse/connectors/reviewable-note-form-after-note/copy-reviewable-note-to-user-option.gjs
@@ -1,0 +1,23 @@
+import Component from "@glimmer/component";
+import { i18n } from "discourse-i18n";
+
+export default class CopyReviewableNoteToUserOption extends Component {
+  static shouldRender(args, context) {
+    return (
+      context.siteSettings.user_notes_enabled && context.currentUser?.staff
+    );
+  }
+
+  <template>
+    <@form.CheckboxGroup as |group|>
+      <group.Field
+        @name="copy_note_to_user"
+        @title={{i18n "user_notes.copy_reviewable_note"}}
+        @format="full"
+        as |field|
+      >
+        <field.Checkbox />
+      </group.Field>
+    </@form.CheckboxGroup>
+  </template>
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,3 +7,4 @@ en:
       show: "User Notes (%{count})"
       delete_confirm: "Are you sure you want to delete that user note?"
       show_post: "Show Post"
+      copy_reviewable_note: "Copy note to user profile?"


### PR DESCRIPTION
## ✨ What's This?

Requires discourse/discourse#32506.

When a note is added to a reviewable, this change allows the note to also be copied to the user notes.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/0c57b694-8064-4401-b3f4-4e27e8e0f570)
![](https://github.com/user-attachments/assets/71814822-6297-4491-8fc4-809ac0144b5d)

## 👑 Testing

Ensure you're using the correct branch of Discourse, since the plugin locations currently only exist in the branch.

Check that the user notes are copied as expected.